### PR TITLE
Add debugging techniques to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # JAVAX
+
+## Explaining Code to a Rubber Duck
+
+Place your rubber duck or any inanimate object nearby. Walk through your code and explain each part to the duck, detailing what it's supposed to do and how it works. Highlight potential issues as you talk through it, as you might notice inconsistencies or errors that you overlooked.
+
+## Using Print Statements for Debugging
+
+* Insert print statements in your code to display the values of variables at different points in the program.
+* Use `System.out.println()` to print messages to the console.
+* This helps you understand the flow of the program and identify where things might be going wrong.
+
+## Using a Debugger in IntelliJ IDEA
+
+* Open your project in IntelliJ IDEA.
+* Navigate to the file where you want to set a breakpoint.
+* Click in the left gutter (the area to the left of the line numbers) next to the line where you want to set the breakpoint. A red dot will appear, indicating that a breakpoint has been set.
+* To remove a breakpoint, click the red dot again.
+* You can also manage breakpoints by going to `Run` > `View Breakpoints` or pressing `Ctrl+Shift+F8` (Windows/Linux) or `Cmd+Shift+F8` (Mac).
+* Once breakpoints are set, start debugging by clicking the bug icon in the toolbar or by selecting `Run` > `Debug`.
+
+## Using Logging Frameworks like Log4j or SLF4J
+
+* **Choose a logging framework**: Decide whether to use Log4j, SLF4J, or another logging framework based on your project's requirements and preferences.
+* **Add the logging framework to your project**: Include the necessary dependencies in your project's build file (e.g., `pom.xml` for Maven or `build.gradle` for Gradle).
+* **Configure the logging framework**: Set up the logging configuration file (e.g., `log4j.properties` or `logback.xml`) to define the logging levels, appenders, and log file locations.
+* **Initialize the logger**: Create a logger instance in your Java classes using the logging framework's API.
+* **Log messages at appropriate levels**: Use different logging levels (e.g., INFO, DEBUG, ERROR) to log messages based on their importance and severity.
+* **Avoid logging sensitive information**: Be cautious not to log sensitive data such as passwords or personal information.
+* **Review and manage log files**: Regularly review the log files to monitor the application's behavior and identify any issues. Implement log rotation and archiving to manage log file sizes.


### PR DESCRIPTION
Add sections to `README.md` to explain debugging techniques and code explanation to a rubber duck.

* **Explaining Code to a Rubber Duck**: Add a section about placing a rubber duck nearby and explaining the code to it, highlighting potential issues.
* **Using Print Statements for Debugging**: Add a section about inserting print statements to display variable values and understand program flow.
* **Using a Debugger in IntelliJ IDEA**: Add a section about setting and managing breakpoints in IntelliJ IDEA.
* **Using Logging Frameworks like Log4j or SLF4J**: Add a section about choosing, adding, configuring, and using logging frameworks, and managing log files.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/JAVAX/pull/1?shareId=5411ef6f-a937-4c8e-816d-e875f8f96984).